### PR TITLE
Add a string argument to custom SDL events

### DIFF
--- a/src/sdlevent.ml
+++ b/src/sdlevent.ml
@@ -107,7 +107,7 @@ type event =
   | SYSWM
   | VIDEORESIZE     of int * int
   | VIDEOEXPOSE
-  | USER            of int
+  | USER            of int * string
 
 let string_of_event = function
   | ACTIVE _        -> "active"
@@ -125,7 +125,7 @@ let string_of_event = function
   | SYSWM           -> "syswm"
   | VIDEORESIZE _   -> "resize"
   | VIDEOEXPOSE     -> "expose"
-  | USER c          -> "user " ^ (string_of_int c)
+  | USER (c,s)      -> "user " ^ (string_of_int c)
 
 type event_kind =
   | ACTIVE_EVENT 

--- a/src/sdlevent.mli
+++ b/src/sdlevent.mli
@@ -128,7 +128,7 @@ type event =
   | SYSWM                                (** System specific event *)
   | VIDEORESIZE     of int * int         (** User resized video mode *)
   | VIDEOEXPOSE                          (** Screen needs to be redrawn *)
-  | USER            of int               (** for your use ! *)
+  | USER            of int * string      (** for your use ! *)
 
 val string_of_event : event -> string
 (** Returns a short string descriptive of the event type, for debugging *)

--- a/src/sdlevent_stub.c
+++ b/src/sdlevent_stub.c
@@ -109,7 +109,7 @@ static value value_of_keyevent(SDL_KeyboardEvent keyevt)
   v = alloc_small(1, tag);
   Field(v, 0) = r;
   CAMLreturn(v);
-} 
+}
 
 static value value_of_mouse_button(Uint8 b)
 {
@@ -218,8 +218,9 @@ static value value_of_SDLEvent(SDL_Event evt)
   case SDL_USEREVENT :
     v = alloc_small(1, 12);
     Field(v, 0) = Val_int(evt.user.code);
+    Field(v, 1) = String_val(evt.user.data1);
     break;
-  default : 
+  default :
     /* unknown event ? -> raise an exception */
     raise_event_exn("unknown event");
   }
@@ -310,7 +311,7 @@ static SDL_Event SDLEvent_of_value(value e)
     case 12:
       evt.type = SDL_USEREVENT ;
       evt.user.code = Int_val(Field(e, 0));
-      evt.user.data1 = NULL;
+      evt.user.data1 = String_val(Field(e, 1));
       evt.user.data2 = NULL;
       break;
     default:
@@ -320,7 +321,7 @@ static SDL_Event SDLEvent_of_value(value e)
   return evt;
 
  invalid:
-  invalid_argument("SDLEvent_of_value"); 
+  invalid_argument("SDLEvent_of_value");
 
   return evt;  /* silence compiler */
 }
@@ -424,15 +425,15 @@ CAMLprim value mlsdlevent_wait_event(value unit)
 }
 
 static const Uint8 evt_type_of_val [] = {
-  SDL_ACTIVEEVENT, SDL_KEYDOWN, SDL_KEYUP, 
+  SDL_ACTIVEEVENT, SDL_KEYDOWN, SDL_KEYUP,
   SDL_MOUSEMOTION, SDL_MOUSEBUTTONDOWN, SDL_MOUSEBUTTONUP,
-  SDL_JOYAXISMOTION, SDL_JOYBALLMOTION, SDL_JOYHATMOTION, 
+  SDL_JOYAXISMOTION, SDL_JOYBALLMOTION, SDL_JOYHATMOTION,
   SDL_JOYBUTTONDOWN, SDL_JOYBUTTONUP, SDL_QUIT, SDL_SYSWMEVENT,
   SDL_VIDEORESIZE, SDL_VIDEOEXPOSE, SDL_USEREVENT, } ;
 
 CAMLprim value mlsdlevent_get_state(value evt_v)
 {
-  return Val_bool( SDL_EventState( evt_type_of_val[ Int_val(evt_v) ], 
+  return Val_bool( SDL_EventState( evt_type_of_val[ Int_val(evt_v) ],
 				   SDL_QUERY) );
 }
 


### PR DESCRIPTION
Adds a string argument to the custom USER event, i.e. the data1 field (https://wiki.libsdl.org/SDL_UserEvent)
